### PR TITLE
Fix event type validator string

### DIFF
--- a/microservices/ace_agent/clients/event_client/event_client.py
+++ b/microservices/ace_agent/clients/event_client/event_client.py
@@ -201,7 +201,7 @@ _event_validators = [
     ),
     Validator(
         "***UtteranceBotActionScriptUpdated events need to provide 'interim_script' of type 'str'",
-        lambda e: e["type"] != "UtteranceBotActionScriptUpdated " or _has_property(e, Property("interim_script", str)),
+        lambda e: e["type"] != "UtteranceBotActionScriptUpdated" or _has_property(e, Property("interim_script", str)),
     ),
     Validator(
         "***UtteranceBotActionFinished events need to provide 'final_script' of type 'str'",


### PR DESCRIPTION
## Summary
- fix trailing space in event name in validator

## Testing
- `python3 -m py_compile microservices/ace_agent/clients/event_client/event_client.py`


------
https://chatgpt.com/codex/tasks/task_b_683b440d211c8327a9a3edfef9974a69